### PR TITLE
Catch and process possible exception on JSTransformer compileAsync and renderAsync

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,11 +56,10 @@ module.exports = function (opts) {
         })
 
         // Compile the content.
-        const content = files[layout].contents.toString()
         let compiling
         try {
           // In some condition jstransformer compileAsync can throw excepton.
-          compiling = transform.compileAsync(content, options)
+          compiling = transform.compileAsync(files[layout].contents.toString(), options)
         } catch (err) {
           return done(err)
         }
@@ -151,7 +150,7 @@ module.exports = function (opts) {
             root: metalsmith.source()
           })
 
-          // Get the transformer to render the contents.
+          // Render the contents.
           let rendering
           try {
             // In some condition jstransformer renderAsync can throw excepton.

--- a/index.js
+++ b/index.js
@@ -57,7 +57,14 @@ module.exports = function (opts) {
 
         // Compile the content.
         const content = files[layout].contents.toString()
-        transform.compileAsync(content, options).then(results => {
+        let compiling
+        try {
+          // In some condition jstransformer compileAsync can throw excepton.
+          compiling = transform.compileAsync(content, options)
+        } catch (err) {
+          return done(err)
+        }
+        compiling.then(results => {
           // Wire up the template for the layout.
           templates[layout] = results
           templates[layout].transformName = transform.name
@@ -145,7 +152,14 @@ module.exports = function (opts) {
           })
 
           // Get the transformer to render the contents.
-          transformer.renderAsync(files[file].contents.toString(), options, locals).then(result => {
+          let rendering
+          try {
+            // In some condition jstransformer renderAsync can throw excepton.
+            rendering = transformer.renderAsync(files[file].contents.toString(), options, locals)
+          } catch (err) {
+            return done(err)
+          }
+          rendering.then(result => {
             // Allow providing the default output format.
             files[file].jstransformerOutputFormat = transformer.outputFormat
             // Remove an extension from the end.


### PR DESCRIPTION
Similarly to problem resolved by #20, because of uncached exception of JSTransformer compileAsync and renderAsync functions, the real problem does not output to console:
```
[13:57:21] Starting 'content'...
[13:57:22] The following tasks did not complete: content
[13:57:22] Did you forget to signal async completion?

Process finished with exit code 0
```

After applying this pull request in output we get more useful information (and correct exit code):
```
[15:31:09] Starting 'content'...
[15:31:10] 'content' errored after 1.06 s
[15:31:10] Error: ENOENT: no such file or directory, open '/Users/ych/projects/test/src/projects/extension/_idea.md'
    at /Users/ych/projects/test/src/projects/extension/index.html.pug line 10
    at Object.fs.openSync (fs.js:667:18)
    at Object.fs.readFileSync (fs.js:572:33)
    at Function.read (/Users/ych/projects/test/node_modules/pug-load/index.js:69:13)
    at Object.read (/Users/ych/projects/test/node_modules/pug/lib/index.js:147:25)
    at /Users/ych/projects/test/node_modules/pug-load/index.js:24:25
    at walkAST (/Users/ych/projects/test/node_modules/pug-walk/index.js:23:18)
    at /Users/ych/projects/test/node_modules/pug-walk/index.js:104:20
    at Array.reduce (<anonymous>)
    at walkAndMergeNodes (/Users/ych/projects/test/node_modules/pug-walk/index.js:103:18)
    at walkAST (/Users/ych/projects/test/node_modules/pug-walk/index.js:37:19)

Process finished with exit code 1
```

This exception throw because of `include:markdown-it _idea.md` Including Plain Text construction in `index.html.pug`.

After some investigation of the reason that async function throw exception I found [next line](https://github.com/jstransformers/jstransformer/blob/62d1ccbecb314d4e97aa2f38f4e707c7f7adbf50/index.js#L167) in [jstransformer](https://github.com/jstransformers/jstransformer) implementation. So yes, it seems [jstransformer](https://github.com/jstransformers/jstransformer) issue, but looking at the date of its last release and count of unresolved issues, I think it will be easy and faster to fix it here.

In future, if the issue of compileAsync and renderAsync methods will be fixed this try/catch blocks could be deleted.